### PR TITLE
Add support for editable layout type (horizontal or vertical)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opportunity-solution-tree",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opportunity-solution-tree",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "devDependencies": {
         "@figma/eslint-plugin-figma-plugins": "^0.16.1",
         "@figma/plugin-typings": "^1.109.0",

--- a/widget-src/code.tsx
+++ b/widget-src/code.tsx
@@ -2,7 +2,7 @@ const { widget } = figma;
 const { AutoLayout, Input, SVG, Text, useSyncedState, usePropertyMenu, useWidgetNodeId } =
   widget;
 import { CardType, cardColors, cardTypes, cartTypeRelations, cardStatuses, CardStatusType, Link, LayoutType, layoutTypes } from './types'
-import { autoLayout, cascadeLayoutChange, collapse, expand, findConnections } from './auto-layout';
+import { autoLayout, cascadeLayoutChange, collapse, expand, findConnections, getState } from './auto-layout';
 
 const placeholderTexts: { [t in CardType]: string } = {
   "Business Outcome": "A measurement of business impact.",
@@ -61,7 +61,8 @@ function ExpandTip({color, widgetId} : { color: string, widgetId: string }) {
           const node = await figma.getNodeByIdAsync(widgetId) as WidgetNode;
           setHeightWOTip(node.height - 18);
           expand(node);
-          cascadeLayoutChange(node);
+          const layoutType = getState<LayoutType>(node, "layoutType");
+          cascadeLayoutChange(node, layoutType);
         }}
         opacity={0.75} horizontalAlignItems="center" padding={{ top: 2 }} width={24} height={18} fill={color} cornerRadius={{ topLeft: 0, topRight: 0, bottomLeft: 20, bottomRight: 20 }}>
         <SVG src='<svg xmlns="http://www.w3.org/2000/svg" height="14" width="12" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path fill="#333" d="M201.4 342.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 274.7 86.6 137.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"/></svg>' />
@@ -530,19 +531,19 @@ function Widget() {
         }
 
         case 'auto-layout': {
-          autoLayout(thisWidget);
+          autoLayout(thisWidget, layoutType);
           break;
         }
 
         case 'collapse': {
           collapse(thisWidget);
-          cascadeLayoutChange(thisWidget);
+          cascadeLayoutChange(thisWidget, layoutType);
           break;
         }
 
         case 'expand-all': {
           expand(thisWidget, true);
-          cascadeLayoutChange(thisWidget);
+          cascadeLayoutChange(thisWidget, layoutType);
           break;
         }
 

--- a/widget-src/code.tsx
+++ b/widget-src/code.tsx
@@ -329,6 +329,8 @@ async function propagateLayoutType(widget: WidgetNode, newLayoutType: LayoutType
   
   // Propagate down from the root
   await propagateLayoutTypeToChildren(root, newLayoutType);
+
+  cascadeLayoutChange(root, newLayoutType);
 }
 
 function Widget() {
@@ -532,6 +534,7 @@ function Widget() {
 
         case 'auto-layout': {
           autoLayout(thisWidget, layoutType);
+          cascadeLayoutChange(thisWidget, layoutType);
           break;
         }
 

--- a/widget-src/code.tsx
+++ b/widget-src/code.tsx
@@ -308,11 +308,11 @@ async function propagateLayoutTypeToChildren(widget: WidgetNode, newLayoutType: 
     const startEndpoint = parentConnector.connectorStart as ConnectorEndpointEndpointNodeIdAndMagnet;
     parentConnector.connectorStart = {
       endpointNodeId: startEndpoint.endpointNodeId, // Keep the parent's ID
-      magnet: newLayoutType === 'Horizontal' ? 'RIGHT' : 'BOTTOM'
+      magnet: newLayoutType === 'Vertical' ? 'BOTTOM' : 'RIGHT'
     };
     parentConnector.connectorEnd = {
       endpointNodeId: widget.id,
-      magnet: newLayoutType === 'Horizontal' ? 'LEFT' : 'TOP'
+      magnet: newLayoutType === 'Vertical' ? 'TOP' : 'LEFT'
     };
   }
   
@@ -349,7 +349,7 @@ function Widget() {
         itemType: "dropdown",
         options: layoutTypes.map((i) => ({ option: i, label: i })),
         selectedOption: layoutType.toString(),
-        tooltip: "Layout",
+        tooltip: "OST layout",
         propertyName: "layoutType",
       },
       {
@@ -362,7 +362,7 @@ function Widget() {
                <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                <path fill="#CCC" d="M214.6 9.4c-12.5-12.5-32.8-12.5-45.3 0l-128 128c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 109.3 160 480c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 73.4 73.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-128-128z"/>
                </svg>`,
-        tooltip: layoutType === 'Horizontal' ? "Create sibling above" : "Create parent"
+        tooltip: layoutType === 'Vertical' ? "Create parent" : "Create sibling above"
       },
       {
         itemType: "action",
@@ -371,7 +371,7 @@ function Widget() {
                <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                <path fill="#CCC" d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l128-128c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7L86.6 329.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l128 128z"/>
                </svg>`,
-        tooltip: layoutType === 'Horizontal' ? "Create sibling below" : "Create child"
+        tooltip: layoutType === 'Vertical' ? "Create child" : "Create sibling below"
       },
       {
         itemType: "action",
@@ -380,7 +380,7 @@ function Widget() {
                <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                <path fill="#CCC" d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/>
                </svg>`,
-        tooltip: layoutType === 'Horizontal' ? "Create parent" : "Create sibling to the left"
+        tooltip: layoutType === 'Vertical' ? "Create sibling to the left" : "Create parent"
       },
       {
         itemType: "action",
@@ -389,7 +389,7 @@ function Widget() {
                <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
                <path fill="#CCC" d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"/>
                </svg>`,
-        tooltip: layoutType === 'Horizontal' ? "Create child" : "Create sibling to the right"
+        tooltip: layoutType === 'Vertical' ? "Create sibling to the right" : "Create child"
       },
       {
         itemType: "separator"
@@ -471,54 +471,55 @@ function Widget() {
           break;
 
         case "new-left": {
-          if (layoutType === 'Horizontal') {
+          if (layoutType === 'Vertical') {
+            // Create sibling to the left in vertical layout
+            await createSibling(widgetId, cardType, parentWidgetId, layoutType, -100, 0);
+            
+          } else {
             // Create parent in horizontal layout
             const newWidget = await createParent(widgetId, cardType, layoutType, -100, 0);
             if (newWidget) {
               setParentWidgetId(newWidget.id);
             }
-          } else {
-            // Create sibling to the left in vertical layout
-            await createSibling(widgetId, cardType, parentWidgetId, layoutType, -100, 0);
           }
           //cascadeLayoutChange(thisWidget);
           break;
         }
 
         case 'new-right': {
-          if (layoutType === 'Horizontal') {
-            // Create child in horizontal layout
-            await createChild(widgetId, cardType, layoutType, 100, 0);
-          } else {
+          if (layoutType === 'Vertical') {
             // Create sibling to the right in vertical layout
             await createSibling(widgetId, cardType, parentWidgetId, layoutType, 100, 0);
+          } else {
+            // Create child in horizontal layout
+            await createChild(widgetId, cardType, layoutType, 100, 0);
           }
           //cascadeLayoutChange(thisWidget);
           break;
         }
 
         case 'new-top': {
-          if (layoutType === 'Horizontal') {
-            // Create sibling above in horizontal layout
-            await createSibling(widgetId, cardType, parentWidgetId, layoutType, 0, -50);
-          } else {
+          if (layoutType === 'Vertical') {
             // Create parent in vertical layout
             const newWidget = await createParent(widgetId, cardType, layoutType, 0, -50);
             if (newWidget) {
               setParentWidgetId(newWidget.id);
             }
+          } else {
+            // Create sibling above in horizontal layout
+            await createSibling(widgetId, cardType, parentWidgetId, layoutType, 0, -50);
           }
           //cascadeLayoutChange(thisWidget);
           break;
         }
 
         case 'new-bottom': {
-          if (layoutType === 'Horizontal') {
-            // Create sibling below in horizontal layout
-            await createSibling(widgetId, cardType, parentWidgetId, layoutType, 0, 50);
-          } else {
+          if (layoutType === 'Vertical') {
             // Create child in vertical layout
             await createChild(widgetId, cardType, layoutType, 0, 50);
+          } else {
+            // Create sibling below in horizontal layout
+            await createSibling(widgetId, cardType, parentWidgetId, layoutType, 0, 50);
           }
           //cascadeLayoutChange(thisWidget);
           break;
@@ -534,7 +535,6 @@ function Widget() {
 
         case 'auto-layout': {
           autoLayout(thisWidget, layoutType);
-          cascadeLayoutChange(thisWidget, layoutType);
           break;
         }
 

--- a/widget-src/types.ts
+++ b/widget-src/types.ts
@@ -1,3 +1,7 @@
+export type LayoutType = "Horizontal" | "Vertical";
+
+export const layoutTypes: LayoutType[] = ["Horizontal", "Vertical"];
+
 export type CardType =
   | "Business Outcome"
   | "Product Outcome"


### PR DESCRIPTION
Currently, auto-layout structures the tree vertically. In a vertical layout, wider OSTs (with many nodes on the same level, eg multiple sibling opportunities for the same product outcome) can be more difficult to navigate due to heavier reliance on side scrolling.

To better support wider OSTs, but still keep the advantages of a vertical layout (for taller trees, with less siblings), this PR introduces an editable layout type property (`LayoutType`):

**A. Vertical** (currently supported layout), where children are placed underneath their parent

![image](https://github.com/user-attachments/assets/a603e59d-f50d-4950-b9c5-9bb16b82d3a5)

**B. Horizontal**, where children are placed to the side of their parent

![image](https://github.com/user-attachments/assets/9331a336-5fb8-4005-9532-373b8b03a869)

---

Key changes:
- Added `LayoutType` property
- Implemented propagation of layout type across the OST, as the property is intended to be tree-wide 
- Updated widget creation and connection logic to respect layout orientation: the directional `up`, `down`, `left`, `right` actions in the property menu adapt to the current layout
- Modified auto-layout calculations to handle both layout types

The changes maintain backward compatibility while adding the ability to switch between layout orientations. 