### PR TITLE
Preserve the order of widget nodes when changing LayoutType

### DIFF
--- a/widget-src/auto-layout.ts
+++ b/widget-src/auto-layout.ts
@@ -1,5 +1,5 @@
 //const widgetName = "Opportunity Solution Tree";
-import { LayoutType } from "./types";
+import { LayoutType, LayoutContext } from "./types";
 
 const margin = { vertical: 80, horizontal: 80 };
 
@@ -28,12 +28,22 @@ export function getState<T>(widget: WidgetNode, key: string): T {
     return widget.widgetSyncedState[key] as T;
 }
 
-export function autoLayout(widget: WidgetNode, layoutType: LayoutType) {
-    updateBox(widget, layoutType);
-    reposition(widget, layoutType, "children");
+export function autoLayout(widget: WidgetNode, layoutContext: LayoutContext) {
+    updateBox(widget, layoutContext);
+    reposition(widget, layoutContext, "children");
 }
 
-export async function findConnections(widget: WidgetNode): Promise<WidgetConnections> {
+function sortWidgetNodes(nodes: { widget: WidgetNode }[], layoutContext: LayoutContext) {
+    // To preserve sibling order, sorting is done based on the previous layout type
+    // Previous type is different from current only when the tree's layout type has changed
+    const layoutType = layoutContext.previousLayoutType;
+    nodes.sort((a, b) => layoutType === "Vertical" 
+        ? a.widget.x - b.widget.x 
+        : a.widget.y - b.widget.y
+    );
+}
+
+export async function findConnections(widget: WidgetNode, layoutContext: LayoutContext): Promise<WidgetConnections> {
     const conns = { widget: widget, parents: [], children: [] } as WidgetConnections;
 
     for (const con of widget.attachedConnectors) {
@@ -50,14 +60,15 @@ export async function findConnections(widget: WidgetNode): Promise<WidgetConnect
         }
     }
 
-    conns.children.sort((a, b) => a.widget.x - b.widget.x);
+    sortWidgetNodes(conns.children, layoutContext);
 
     return conns;
 }
 
-async function updateBox(node: WidgetNode, layoutType: LayoutType): Promise<BoxDimensions> {
+async function updateBox(node: WidgetNode, layoutContext: LayoutContext): Promise<BoxDimensions> {
+    const layoutType = layoutContext.currentLayoutType;
     // This function will always update descedants recursively.
-    const children = (await findConnections(node)).children;
+    const children = (await findConnections(node, layoutContext)).children;
 
     if (getState(node, "hideChildren") == true || children.length == 0) {
         return setBox(node, { width: node.width, height: node.height, xOffset: 0, yOffset: 0 });
@@ -67,29 +78,31 @@ async function updateBox(node: WidgetNode, layoutType: LayoutType): Promise<BoxD
 
     if (layoutType === "Vertical") {
         for(const child of children) {
-            myBox.width += (await updateBox(child.widget, layoutType)).width;
+            myBox.width += (await updateBox(child.widget, layoutContext)).width;
         }
         // add spacing in between
         myBox.width += (children.length - 1) * margin.horizontal;
         // calculate x offset
-        myBox.xOffset = await calcLayoutOffset(myBox.width, node.width, children, layoutType);
+        myBox.xOffset = await calcLayoutOffset(myBox.width, node.width, children, layoutContext);
     } else {
         for(const child of children) {
-            myBox.height += (await updateBox(child.widget, layoutType)).height;
+            myBox.height += (await updateBox(child.widget, layoutContext)).height;
         }
         // add spacing in between
         myBox.height += (children.length - 1) * margin.vertical;
         // calculate y offset
-        myBox.yOffset = await calcLayoutOffset(myBox.height, node.height, children, layoutType);
+        myBox.yOffset = await calcLayoutOffset(myBox.height, node.height, children, layoutContext);
     }
 
     return setBox(node, myBox);
 }
 
-async function calcLayoutOffset(parentBoxSize: number, parentSize: number, children: { widget: WidgetNode }[], layoutType: LayoutType ): Promise<number> {
-    const firstChildBox = await getBox(children[0].widget, layoutType);
+async function calcLayoutOffset(parentBoxSize: number, parentSize: number, children: { widget: WidgetNode }[], layoutContext: LayoutContext): Promise<number> {
+    const layoutType = layoutContext.currentLayoutType;
+    
+    const firstChildBox = await getBox(children[0].widget, layoutContext);
     const lastChild = children[children.length - 1];
-    const lastChildBox = await getBox(lastChild.widget, layoutType);
+    const lastChildBox = await getBox(lastChild.widget, layoutContext);
 
     const firstChildBoxOffset = layoutType === "Vertical" ? firstChildBox.xOffset : firstChildBox.yOffset;
     const lastChildBoxOffset = layoutType === "Vertical" ? lastChildBox.xOffset : lastChildBox.yOffset;
@@ -102,26 +115,26 @@ async function calcLayoutOffset(parentBoxSize: number, parentSize: number, child
     return firstChildBoxOffset + offsetToChildren;
 }
 
-async function updateParentBox(parent: WidgetNode, layoutType: LayoutType): Promise<BoxDimensions> {
+async function updateParentBox(parent: WidgetNode, layoutContext: LayoutContext): Promise<BoxDimensions> {
+    const layoutType = layoutContext.currentLayoutType;
     // This assumes children boxes are already up-to-date
     // This would only occur when propogating thus this node will not be hidden
-
-    const children = (await findConnections(parent)).children;
+    const children = (await findConnections(parent, layoutContext)).children;
 
     const pBox = { width: 0, height: 0, xOffset: 0, yOffset: 0 };
 
     if (layoutType === "Vertical") {
         for(const child of children) {
-            pBox.width += (await getBox(child.widget, layoutType)).width;
+            pBox.width += (await getBox(child.widget, layoutContext)).width;
         }
         pBox.width += (children.length - 1) * margin.horizontal;
-        pBox.xOffset = await calcLayoutOffset(pBox.width, parent.width, children, layoutType);
+        pBox.xOffset = await calcLayoutOffset(pBox.width, parent.width, children, layoutContext);
     } else {
         for(const child of children) {
-            pBox.height += (await getBox(child.widget, layoutType)).height;
+            pBox.height += (await getBox(child.widget, layoutContext)).height;
         }
         pBox.height += (children.length - 1) * margin.vertical;
-        pBox.yOffset = await calcLayoutOffset(pBox.height, parent.height, children, layoutType);
+        pBox.yOffset = await calcLayoutOffset(pBox.height, parent.height, children, layoutContext);
     }
 
     return setBox(parent, pBox);
@@ -132,16 +145,17 @@ function setBox(widget: WidgetNode, box: BoxDimensions) {
     return box;
 }
 
-async function getBox(widget: WidgetNode, layoutType: LayoutType): Promise<BoxDimensions> {
+async function getBox(widget: WidgetNode, layoutContext: LayoutContext): Promise<BoxDimensions> {
     let box = getState<BoxDimensions>(widget, "box");
     if (box == null) {
-        box = await updateBox(widget, layoutType);
+        box = await updateBox(widget, layoutContext);
     }
     return box;
 }
 
-async function moveChildrenByBoxDim(anchor: WidgetNode, layoutType: LayoutType) {
-    const children = (await findConnections(anchor)).children;
+async function moveChildrenByBoxDim(anchor: WidgetNode, layoutContext: LayoutContext) {
+    const layoutType = layoutContext.currentLayoutType;
+    const children = (await findConnections(anchor, layoutContext)).children;
     if (children.length === 0) return;
 
     const storedHeight = getState<number>(anchor, "heightWOTip");
@@ -154,7 +168,7 @@ async function moveChildrenByBoxDim(anchor: WidgetNode, layoutType: LayoutType) 
         const y = anchor.y + widgetHeight + margin.vertical;
         
         const startingX =
-        anchor.x - (await getBox(anchor, layoutType)).xOffset + (children.length > 0 ? (await getBox(children[0].widget, layoutType)).xOffset : 0);        
+        anchor.x - (await getBox(anchor, layoutContext)).xOffset + (children.length > 0 ? (await getBox(children[0].widget, layoutContext)).xOffset : 0);        
 
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
@@ -164,18 +178,18 @@ async function moveChildrenByBoxDim(anchor: WidgetNode, layoutType: LayoutType) 
                 child.widget.x = startingX;
             } else {
                 const prevChild = children[i - 1];
-                const prevChildBox = await getBox(prevChild.widget, layoutType);
+                const prevChildBox = await getBox(prevChild.widget, layoutContext);
                 const prevChildXRight = prevChild.widget.x - prevChildBox.xOffset + prevChildBox.width;
-                child.widget.x = prevChildXRight + margin.horizontal + (await getBox(child.widget, layoutType)).xOffset;
+                child.widget.x = prevChildXRight + margin.horizontal + (await getBox(child.widget, layoutContext)).xOffset;
             }
-            moveChildrenByBoxDim(child.widget, layoutType);
+            moveChildrenByBoxDim(child.widget, layoutContext);
         }
     } else {
         // Horizontal layout: children are arranged vertically to the right of the parent
         const x = anchor.x + widgetWidth + margin.horizontal;
 
         const startingY =
-        anchor.y - (await getBox(anchor, layoutType)).yOffset + (children.length > 0 ? (await getBox(children[0].widget, layoutType)).yOffset : 0);
+        anchor.y - (await getBox(anchor, layoutContext)).yOffset + (children.length > 0 ? (await getBox(children[0].widget, layoutContext)).yOffset : 0);
 
         for (let i = 0; i < children.length; i++) {
             const child = children[i];
@@ -185,19 +199,19 @@ async function moveChildrenByBoxDim(anchor: WidgetNode, layoutType: LayoutType) 
                 child.widget.y = startingY;
             } else {
                 const prevChild = children[i - 1];
-                const prevChildBox = await getBox(prevChild.widget, layoutType);
+                const prevChildBox = await getBox(prevChild.widget, layoutContext);
                 const prevChildYBottom = prevChild.widget.y - prevChildBox.yOffset + prevChildBox.height;
-                child.widget.y = prevChildYBottom + margin.vertical + (await getBox(child.widget, layoutType)).yOffset;
+                child.widget.y = prevChildYBottom + margin.vertical + (await getBox(child.widget, layoutContext)).yOffset;
             }
-            moveChildrenByBoxDim(child.widget, layoutType);
+            moveChildrenByBoxDim(child.widget, layoutContext);
         }
     }
 }
 
-export async function collapse(widget: WidgetNode) {
-    const children = (await findConnections(widget)).children;
+export async function collapse(widget: WidgetNode, layoutContext: LayoutContext) {
+    const children = (await findConnections(widget, layoutContext)).children;
     children.forEach(el => {
-        collapse(el.widget);
+        collapse(el.widget, layoutContext);
         el.widget.visible = false;
         el.connector.visible = false;
     });
@@ -206,20 +220,21 @@ export async function collapse(widget: WidgetNode) {
     return children.length;
 }
 
-export async function expand(widget: WidgetNode, recursive?: boolean) {
-    const children = (await findConnections(widget)).children;
+export async function expand(widget: WidgetNode, layoutContext: LayoutContext, recursive?: boolean) {
+    const children = (await findConnections(widget, layoutContext)).children;
     children.forEach(el => {
         el.widget.visible = true;
         el.connector.visible = true;
-        if (recursive) expand(el.widget, recursive);
+        if (recursive) expand(el.widget, layoutContext, recursive);
     });
     setState(widget, "hideChildren", false);
     return children.length; 
 }
 
-export async function cascadeLayoutChange(widget: WidgetNode, layoutType: LayoutType) {
-    const prevBox = await getBox(widget, layoutType);
-    const currBox = await updateBox(widget, layoutType);
+export async function cascadeLayoutChange(widget: WidgetNode, layoutContext: LayoutContext) {
+    const layoutType = layoutContext.currentLayoutType;
+    const prevBox = await getBox(widget, layoutContext);
+    const currBox = await updateBox(widget, layoutContext);
 
     const currBoxSize = layoutType === "Vertical" ? currBox.width : currBox.height;
     const prevBoxSize = layoutType === "Vertical" ? prevBox.width : prevBox.height;
@@ -227,33 +242,29 @@ export async function cascadeLayoutChange(widget: WidgetNode, layoutType: Layout
     const prevBoxOffset = layoutType === "Vertical" ? prevBox.xOffset : prevBox.yOffset;
 
     if (prevBox && prevBoxSize == currBoxSize && prevBoxOffset == currBoxOffset){
-        reposition(widget, layoutType, "children"); // even if the box dimensions don't change, the nodes positions might have been manually adjusted
+        reposition(widget, layoutContext, "children"); // even if the box dimensions don't change, the nodes positions might have been manually adjusted
         return;
     }
     else{
-        reposition(widget, layoutType, "children");
-        reposition(widget, layoutType, "siblings");
-        reposition(widget, layoutType, "parent");
+        reposition(widget, layoutContext, "children");
+        reposition(widget, layoutContext, "siblings");
+        reposition(widget, layoutContext, "parent");
     }
 }
 
-async function reposition(widget: WidgetNode, layoutType: LayoutType, direction: "children" | "siblings" | "parent") {
+async function reposition(widget: WidgetNode, layoutContext: LayoutContext,direction: "children" | "siblings" | "parent") {
+    const layoutType = layoutContext.currentLayoutType;
     switch (direction) {
         case "children": {  // previously "down"
-            moveChildrenByBoxDim(widget, layoutType);
+            moveChildrenByBoxDim(widget, layoutContext);
             break;
         }
 
         case "siblings": {  // previously "across"
-            const parents = (await findConnections(widget)).parents;
+            const parents = (await findConnections(widget, layoutContext)).parents;
             if (parents.length <= 0) break;
 
-            const siblings = (await findConnections(parents[0].widget)).children;
-            // Sort based on layout direction
-            siblings.sort((a, b) => layoutType === "Vertical" 
-                ? a.widget.x - b.widget.x 
-                : a.widget.y - b.widget.y
-            );
+            const siblings = (await findConnections(parents[0].widget, layoutContext)).children;
 
             const self = siblings.find(e => e.widget.id == widget.id);
             if (self == null) throw new Error("Can't find myself in parent's children!");
@@ -263,45 +274,45 @@ async function reposition(widget: WidgetNode, layoutType: LayoutType, direction:
             for (let i = currPos - 1; i >= 0; i--) {
                 const move = siblings[i];
                 const ref = siblings[i + 1];
-                const refBox = await getBox(ref.widget, layoutType);
-                const moveBox = await getBox(move.widget, layoutType);
+                const refBox = await getBox(ref.widget, layoutContext);
+                const moveBox = await getBox(move.widget, layoutContext);
                 
                 if (layoutType === "Vertical")
                     move.widget.x = ref.widget.x - refBox.xOffset - margin.horizontal - moveBox.width + moveBox.xOffset;
                 else
                     move.widget.y = ref.widget.y - refBox.yOffset - margin.vertical - moveBox.height + moveBox.yOffset;
                 
-                moveChildrenByBoxDim(move.widget, layoutType);
+                moveChildrenByBoxDim(move.widget, layoutContext);
             }
 
             // move the ones after current
             for (let i = currPos + 1; i < siblings.length; i++) {
                 const move = siblings[i];
                 const ref = siblings[i - 1];
-                const refBox = await getBox(ref.widget, layoutType);
-                const moveBox = await getBox(move.widget, layoutType);
+                const refBox = await getBox(ref.widget, layoutContext);
+                const moveBox = await getBox(move.widget, layoutContext);
                 
                 if (layoutType === "Vertical")
                     move.widget.x = ref.widget.x - refBox.xOffset + refBox.width + margin.horizontal + moveBox.xOffset;
                 else
                     move.widget.y = ref.widget.y - refBox.yOffset + refBox.height + margin.vertical + moveBox.yOffset;
 
-                moveChildrenByBoxDim(move.widget, layoutType);
+                moveChildrenByBoxDim(move.widget, layoutContext);
             }
             break;
         }
 
         case "parent": {  // previously "up"
-            const parents = (await findConnections(widget)).parents;
+            const parents = (await findConnections(widget, layoutContext)).parents;
             if (parents.length <= 0) break;
 
             const parent = parents[0];
-            const parentBox = await updateParentBox(parent.widget, layoutType);
-            const siblings = (await findConnections(parent.widget)).children;
+            const parentBox = await updateParentBox(parent.widget, layoutContext);
+            const siblings = (await findConnections(parent.widget, layoutContext)).children;
             const first = siblings[0];
             const last = siblings[siblings.length - 1];
-            const lastBox = await getBox(last.widget, layoutType);
-            const firstBox = await getBox(first.widget, layoutType);
+            const lastBox = await getBox(last.widget, layoutContext);
+            const firstBox = await getBox(first.widget, layoutContext);
 
             const firstBoxOffset = layoutType === "Vertical" ? firstBox.xOffset : firstBox.yOffset;
             const lastBoxOffset = layoutType === "Vertical" ? lastBox.xOffset : lastBox.yOffset;
@@ -318,8 +329,8 @@ async function reposition(widget: WidgetNode, layoutType: LayoutType, direction:
             else
                 parent.widget.y = first.widget.y + parentOffset;
             
-            reposition(parent.widget, layoutType, "siblings");
-            reposition(parent.widget, layoutType, "parent");
+            reposition(parent.widget, layoutContext, "siblings");
+            reposition(parent.widget, layoutContext, "parent");
             break;
         }
         

--- a/widget-src/types.ts
+++ b/widget-src/types.ts
@@ -2,6 +2,11 @@ export type LayoutType = "Horizontal" | "Vertical";
 
 export const layoutTypes: LayoutType[] = ["Horizontal", "Vertical"];
 
+export interface LayoutContext {
+  previousLayoutType: LayoutType;
+  currentLayoutType: LayoutType;
+}
+
 export type CardType =
   | "Business Outcome"
   | "Product Outcome"


### PR DESCRIPTION
Currently, the sorting of widget nodes doesn't fully take into account the LayoutType, and can change the order of nodes in horizontal layout. 

To preserver the order of widget nodes, we are updating sorting to:

- Sort by `x` position for a vertically arranged tree, sort by `y` position for horizontally arranged trees
- Take into account the previous LayoutType. When LayoutType changes, we are now sorting by the previous layout (which contained the right order of nodes) and repositioning based on the new layout

Key changes:

- Added LayoutContext type, which stores the previous and current LayoutType
- Updated sorting to take into account the LayoutContext